### PR TITLE
Fix textbox data-binding.

### DIFF
--- a/MainPage.xaml
+++ b/MainPage.xaml
@@ -9,7 +9,7 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <StackPanel>
-        <TextBox Header="Local Path" Margin="0,0,0,16" Text="{Binding LocalPath, UpdateSourceTrigger=PropertyChanged}"/>
+        <TextBox Header="Local Path" Margin="0,0,0,16" Text="{x:Bind ViewModel.LocalPath}" x:DefaultBindMode="TwoWay"/>
         <Button Content="Choose Folder" Margin="0,0,0,16" Command="{Binding SelectLocalPathCommand}"/>
     </StackPanel>
 </Page>

--- a/MainPage.xaml.cs
+++ b/MainPage.xaml.cs
@@ -12,6 +12,7 @@ using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
+using MVVM_TextBox.ViewModels;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -23,10 +24,12 @@ namespace MVVM_TextBox
     /// </summary>
     public sealed partial class MainPage : Page
     {
+        public MainPageViewModel ViewModel { get; set; }
         public MainPage()
         {
             this.InitializeComponent();
-            DataContext = new ViewModels.MainPageViewModel();
+            this.ViewModel = new MainPageViewModel();
+            DataContext = ViewModel;
         }
     }
 }


### PR DESCRIPTION
WinUI TextBox ignores UpdateSourceTrigger. It works with x:Bind and x:DefaultBindMode.
WinUI TextBox doesn't work with DataContext but looks to local properties => storing ViewModel locally.

Fixes thomasclaudiushuber/mvvmgen#19